### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,10 +83,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is-terminal"
@@ -136,6 +158,12 @@ dependencies = [
  "toml",
  "xdg",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "nix"
@@ -214,6 +242,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -365,11 +402,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -480,7 +542,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "xdg"
-version = "2.5.2"
+name = "winnow"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,15 +101,15 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.173"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags",
  "libc",

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
           overlays = overlays;
         };
         rust = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [ "rust-src" ];
+          extensions = [ "rust-src" "rust-analyzer" ];
         };
 
       in

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -62,8 +62,6 @@ in {
 
     # Create configuration file and directory
     home.file.".config/lumd/.keep".text = "";
-    home.file.".local/share/lumd/.keep".text = "";
-    home.file.".cache/lumd/.keep".text = "";
 
     # Create configuration file
     xdg.configFile."lumd/config.toml".text = ''
@@ -101,7 +99,6 @@ in {
         # Environment variables
         Environment = [
           "XDG_CONFIG_HOME=%h/.config"
-          "XDG_CACHE_HOME=%h/.cache"
           "XDG_RUNTIME_DIR=%t"
         ];
         
@@ -115,7 +112,7 @@ in {
         NoNewPrivileges = true;
         ProtectSystem = "strict";
         ProtectHome = "read-write";
-        ReadWritePaths = "%h/.config/lumd %h/.local/share/lumd %h/.cache/lumd";
+        ReadWritePaths = "%h/.config/lumd";
         RuntimeDirectory = "lumd";
         RuntimeDirectoryMode = "0755";
         # Use ReadWritePaths instead of ConfigurationDirectory to avoid permission conflicts

--- a/lumctl/Cargo.toml
+++ b/lumctl/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 nix = { version = "0.30.1", features = ["user"] }
-xdg = "2.5"
+xdg = "3.0.0"
 
 # Use manual argument parsing to avoid clap's platform-specific dependencies
 # We'll implement simple argument parsing manually

--- a/lumd.service
+++ b/lumd.service
@@ -9,7 +9,6 @@ ExecStart=%h/.nix-profile/bin/lumd
 Restart=on-failure
 RestartSec=5
 Environment=XDG_CONFIG_HOME=%h/.config
-Environment=XDG_CACHE_HOME=%h/.cache
 Environment=XDG_RUNTIME_DIR=%t
 
 # Logging
@@ -22,7 +21,7 @@ PrivateTmp=true
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=read-write
-ReadWritePaths=%h/.config/lumd %h/.local/share/lumd %h/.cache/lumd
+ReadWritePaths=%h/.config/lumd
 RuntimeDirectory=lumd
 RuntimeDirectoryMode=0755
 # Use ReadWritePaths instead of ConfigurationDirectory to avoid permission conflicts

--- a/lumd/Cargo.toml
+++ b/lumd/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2024"
 [dependencies]
 nix = { version = "0.30.1", features = ["user"] }
 slog = "2.7.0"
-slog-async = "2.7.0"
-slog-term = "2.9.0"  # Use slog-term for human-readable logs
+slog-async = "2.8.0"
+slog-term = "2.9.1"  # Use slog-term for human-readable logs
 # Use manual struct serialization instead of derive to avoid proc-macro issues
-serde = { version = "1.0", default-features = false, features = ["std"] }
-xdg = "2.5"
-signal-hook = "0.3.17"
+serde = { version = "1.0.219", default-features = false, features = ["std"] }
+xdg = "3.0.0"
+signal-hook = "0.3.18"
 
-# TOML with minimal features
-toml = { version = "0.5", default-features = false }
+# TOML with parse feature enabled
+toml = { version = "0.8.23", default-features = false, features = ["parse"] }
 
 # No direct libc dependency
 

--- a/lumd/src/paths.rs
+++ b/lumd/src/paths.rs
@@ -3,10 +3,6 @@ use std::path::PathBuf;
 use xdg::BaseDirectories;
 
 pub struct Paths {
-    // Base directories
-    pub config_dir: PathBuf,
-    pub runtime_dir: PathBuf,
-    pub cache_dir: PathBuf,
     pub config_file_path: PathBuf,
     pub socket_path: PathBuf,
 }
@@ -14,11 +10,7 @@ pub struct Paths {
 impl Paths {
     pub fn new() -> Result<Self> {
         // Create XDG base directories
-        let xdg = BaseDirectories::with_prefix("lumd")
-            .map_err(|e| LumdError::InvalidData(format!("XDG error: {}", e)))?;
-
-        // Get the base directories
-        let config_dir = xdg.get_config_home();
+        let xdg = BaseDirectories::with_prefix("lumd");
 
         // Runtime directory handling
         // First try XDG_RUNTIME_DIR (the standard environment variable)
@@ -38,8 +30,6 @@ impl Paths {
             })?;
         }
 
-        let cache_dir = xdg.get_cache_home();
-
         // Create config file path
         let config_file_path = xdg
             .place_config_file("config.toml")
@@ -49,9 +39,6 @@ impl Paths {
         let socket_path = runtime_dir.join("lumd.sock");
 
         Ok(Self {
-            config_dir,
-            runtime_dir,
-            cache_dir,
             config_file_path,
             socket_path,
         })

--- a/shell.nix
+++ b/shell.nix
@@ -10,9 +10,8 @@ if builtins ? getFlake
 then defaultShell
 else pkgs.mkShell {
   packages = with pkgs; [
+    
     # Basic development dependencies
-    rustc
-    cargo
     pkg-config
     glibc
     glibc.dev
@@ -25,6 +24,13 @@ else pkgs.mkShell {
     # System libraries needed for nix crate
     openssl
     openssl.dev
+
+    # Rust
+    rustc
+    cargo
+    clippy
+    rustfmt
+    rust-analyzer
   ];
 
   # Set environment variables

--- a/test_logger_proj/Cargo.toml
+++ b/test_logger_proj/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 slog = "2.7.0"
-slog-term = "2.9.0"
-slog-async = "2.7.0"
+slog-term = "2.9.1"
+slog-async = "2.8.0"


### PR DESCRIPTION
Update dependencies and remove unused directory fields
- Update serde to 1.0.219
- Update xdg to 3.0.0 and fix API usage
- Update signal-hook to 0.3.18
- Update slog-async to 2.8.0 and slog-term to 2.9.1
- Update toml to 0.8.23 with parse feature
- Remove unused config_dir, runtime_dir, and cache_dir fields from Paths struct
- Clean up systemd service files to remove references to unused directories